### PR TITLE
Update README.md to include the property `disableUnderline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ import ChipInput from 'material-ui-chip-input'
 |defaultValue|`array`||The chips to display by default (for uncontrolled mode).|
 |delayBeforeAdd|`bool`|`false`|Use `setTimeout` 150ms delay before adding chips in case other input callbacks like `onSelection` need to fire first.|
 |disabled|`bool`||Disables the chip input if set to true.|
+|disableUnderline|`bool`|`false`|If `true`, the input will not have an underline.|
 |FormHelperTextProps|`object`||Props to pass through to the `FormHelperText` component.|
 |fullWidth|`bool`||If true, the chip input will fill the available width.|
 |fullWidthInput|`bool`||If true, the input field will always be below the chips and fill the available space. By default, it will try to be beside the chips.|


### PR DESCRIPTION
This props wasn't stated on the README.md.
I've copied the description of the field from the [Material UI's filled input documentation](https://material-ui.com/api/filled-input/#props)